### PR TITLE
Error in line 33 caused the program to fail.

### DIFF
--- a/code/pToT.py
+++ b/code/pToT.py
@@ -30,7 +30,7 @@ def convert(fname, pages=None):
    
 #converts all pdfs in directory pdfDir, saves all resulting txt files to txtdir
 def convertMultiple(pdfDir, txtDir):
-    if pdfDir == "": pdfDir = os.getcwd() + "\\" #if no pdfDir passed in 
+    if pdfDir == "": pdfDir = os.getcwd() + "/" #if no pdfDir passed in 
     for pdf in os.listdir(pdfDir): #iterate through pdfs in pdf directory
         fileExtension = pdf.split(".")[-1]
         if fileExtension == "pdf":


### PR DESCRIPTION
File systems in Unix-like systems use forward slash "/" to mark children directories. The code had a backslash (with the escape sequence) "\\" instead. After resolving this issue, program runs now.